### PR TITLE
Use https URL for grunt-phantomcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/chrisgladd/grunt-phantomcss.git"
+    "url": "https://github.com/chrisgladd/grunt-phantomcss.git"
   },
   "bugs": {
     "url": "https://github.com/chrisgladd/grunt-phantomcss/issues"


### PR DESCRIPTION
Consistent with other URLs. Works on networks that block SSH.
