### PR TITLE
Upgrade to temporary@0.0.8 to fix frozen error

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "phantomjs": "~1.9.2-2",
     "bower": "~1.3.12",
-    "temporary": "0.0.7"
+    "temporary": "0.0.8"
   },
   "peerDependencies": {    
     "grunt": "~0.4.1"


### PR DESCRIPTION
I am submitting this as a PR since your fork doesn't have issues.

When I run the tests with node v0.12.5, I get the following

```
Warning: Cannot define property:48, object is not extensible. Use --force to continue.
```

I believe node changed how it handles Object.freeze(). So I managed to trace it back to the [temporary](https://github.com/vesln/temporary) dependency which has a new release to fix the error.

Turns out someone else figured it out and submitted a fix chrisgladd/grunt-phantomcss#30. Since people use your fork for the bower fix, if you could merge @OlenDavis's PR that'd be awesome.

fixes chrisgladd/grunt-phantomcss#41
